### PR TITLE
Updates to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,19 +4,15 @@ Version: 0.1.0.9000
 Authors@R: 
     person("Ryan", "Zomorrodi", , "rzomor2@uic.edu", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0003-6417-5985"))
-Description: Use R and 'SAS' within reproducible multilingual 'quarto' 
-    documents. Run 'SAS' code blocks interactively, send data back and forth
-    between 'SAS' and R, and render 'SAS' output within quarto documents. 'SAS'
-    connections are established through a combination of 'SASPy' and 
-    'reticulate'.
+Description: Use R and 'SAS' within reproducible multilingual 'quarto'
+    documents. Run 'SAS' code blocks interactively, send data back and
+    forth between 'SAS' and R, and render 'SAS' output within quarto
+    documents. 'SAS' connections are established through a combination of
+    'SASPy' and 'reticulate'.
 License: MIT + file LICENSE
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
-SystemRequirements: 
-    python (>= 3.4.0), 
-    SASPy,
-    java (>= 7) required for IOM access method
+URL: https://docs.ropensci.org/sasquatch,
+    https://github.com/ropensci/sasquatch
+BugReports: https://github.com/ropensci/sasquatch/issues
 Depends: 
     R (>= 4.1.0)
 Imports: 
@@ -32,7 +28,11 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0),
     withr
-URL: https://docs.ropensci.org/sasquatch, https://github.com/ropensci/sasquatch
-BugReports: https://github.com/ropensci/sasquatch/issues
-VignetteBuilder: knitr
+VignetteBuilder: 
+    knitr
 Config/testthat/edition: 3
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2
+SystemRequirements: python (>= 3.4.0), SASPy, java (>= 7) required for IOM
+    access method

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     evaluate,
     htmlwidgets,
     knitr,
-    reticulate,
+    reticulate (>= 1.41.0),
     rlang (>= 1.1.0),
     rstudioapi
 Suggests: 


### PR DESCRIPTION
## Changes
1. `usethis::use_tidy_description`
2. `usethis::use_package("reticulate", min_version = "1.41.0")`

## Rationale
In a `renv` or environment with `reticulate` < 1.41.0, installing `sasquatch` errors with a poor message. Essentially it says `py_require()` is not exported from `reticulate`. Hopefully these changes help to resolve that error.

<img width="1026" height="662" alt="Screenshot 2025-09-17 205912" src="https://github.com/user-attachments/assets/5c305c12-d991-4086-aa01-1837f51623a9" />
